### PR TITLE
Removes unused "import math" from examples

### DIFF
--- a/examples/char_lcd.py
+++ b/examples/char_lcd.py
@@ -1,6 +1,5 @@
 #!/usr/bin/python
 # Example using a character LCD connected to a Raspberry Pi or BeagleBone Black.
-import math
 import time
 
 import Adafruit_CharLCD as LCD

--- a/examples/char_lcd_mcp.py
+++ b/examples/char_lcd_mcp.py
@@ -1,6 +1,5 @@
 #!/usr/bin/python
 # Example using an RGB character LCD connected to an MCP23017 GPIO extender.
-import math
 import time
 
 import Adafruit_CharLCD as LCD

--- a/examples/char_lcd_plate.py
+++ b/examples/char_lcd_plate.py
@@ -1,6 +1,5 @@
 #!/usr/bin/python
 # Example using a character LCD plate.
-import math
 import time
 
 import Adafruit_CharLCD as LCD

--- a/examples/char_lcd_rgb.py
+++ b/examples/char_lcd_rgb.py
@@ -1,6 +1,5 @@
 #!/usr/bin/python
 # Example using an RGB character LCD wired directly to Raspberry Pi or BeagleBone Black.
-import math
 import time
 
 import Adafruit_CharLCD as LCD


### PR DESCRIPTION
I was testing my 16x2 LCD display in my Raspberry Pi. I checked the examples and there were some unused "import math" on them.