### PR TITLE
Handling Ctrl+C cleanly

### DIFF
--- a/examples/char_lcd_plate.py
+++ b/examples/char_lcd_plate.py
@@ -1,12 +1,24 @@
 #!/usr/bin/python
 # Example using a character LCD plate.
 import time
+import signal
+import sys
 
 import Adafruit_CharLCD as LCD
 
 
 # Initialize the LCD using the pins 
 lcd = LCD.Adafruit_CharLCDPlate()
+
+def exit_handler(signal, frame):
+    print('Ctrl+C pressed')
+    lcd.clear()	
+    lcd.set_color(0.0, 0.0, 0.0)
+    sys.exit(0)
+
+signal.signal(signal.SIGINT, exit_handler)
+
+print 'Press Ctrl-C to quit.'
 
 # create some custom characters
 lcd.create_char(1, [2, 3, 2, 2, 14, 30, 12, 0])
@@ -64,7 +76,7 @@ buttons = ( (LCD.SELECT, 'Select', (1,1,1)),
             (LCD.DOWN,   'Down'  , (0,1,0)),
             (LCD.RIGHT,  'Right' , (1,0,1)) )
 
-print 'Press Ctrl-C to quit.'
+
 while True:
 	# Loop through each button and check if it is pressed.
 	for button in buttons:


### PR DESCRIPTION
When we ask the user to press Ctrl+C to exit the program, we should
not print a stack trace but reset the LCD display and exit cleanly.

We used to get a message like -
pi@chintu ~/sandbox/Adafruit_Python_CharLCD/examples $ python char_lcd_plate.py
Press Ctrl-C to quit.
♥Traceback (most recent call last):
  File "char_lcd_plate.py", line 71, in <module>
    if lcd.is_pressed(button[0]):
  File "/usr/local/lib/python2.7/dist-packages/Adafruit_CharLCD-1.0.0-py2.7.egg/Adafruit_CharLCD/Adafruit_CharLCD.py", line 450, in is_pressed
    return self._mcp.input(button) == GPIO.LOW
  File "/usr/local/lib/python2.7/dist-packages/Adafruit_GPIO-0.9.3-py2.7.egg/Adafruit_GPIO/MCP230xx.py", line 95, in input
    return self.input_pins([pin])[0]
  File "/usr/local/lib/python2.7/dist-packages/Adafruit_GPIO-0.9.3-py2.7.egg/Adafruit_GPIO/MCP230xx.py", line 103, in input_pins
    gpio = self._device.readList(self.GPIO, self.gpio_bytes)
  File "/usr/local/lib/python2.7/dist-packages/Adafruit_GPIO-0.9.3-py2.7.egg/Adafruit_GPIO/I2C.py", line 129, in readList
    results = self._bus.read_i2c_block_data(self._address, register, length)
KeyboardInterrupt