### PR TITLE
Set cursor to the first character of the first line before printing a message

### DIFF
--- a/Adafruit_CharLCD/Adafruit_CharLCD.py
+++ b/Adafruit_CharLCD/Adafruit_CharLCD.py
@@ -234,6 +234,8 @@ class Adafruit_CharLCD(object):
     def message(self, text):
         """Write text to display.  Note that text can include newlines."""
         line = 0
+        # Ensure that the cursor is on the first character of the first line
+        self.set_cursor(0, line)
         # Iterate through each character.
         for char in text:
             # Advance to next line if character is a new line.

--- a/Adafruit_CharLCD/Adafruit_CharLCD.py
+++ b/Adafruit_CharLCD/Adafruit_CharLCD.py
@@ -232,7 +232,11 @@ class Adafruit_CharLCD(object):
         self.write8(LCD_ENTRYMODESET | self.displaymode)
 
     def message(self, text):
-        """Write text to display.  Note that text can include newlines."""
+        """Write text to display.  Note that text can include newlines.
+        The message will always start on the first character of the first line.
+        Note that it does not clear the LCD by itself, therefore you may still
+        encounter fragment from previous messages, in case they were longer.
+        """
         line = 0
         # Move to left or right side depending on text direction.
         col = 0 if self.displaymode & LCD_ENTRYLEFT > 0 else self._cols-1

--- a/Adafruit_CharLCD/Adafruit_CharLCD.py
+++ b/Adafruit_CharLCD/Adafruit_CharLCD.py
@@ -234,15 +234,15 @@ class Adafruit_CharLCD(object):
     def message(self, text):
         """Write text to display.  Note that text can include newlines."""
         line = 0
+        # Move to left or right side depending on text direction.
+        col = 0 if self.displaymode & LCD_ENTRYLEFT > 0 else self._cols-1
         # Ensure that the cursor is on the first character of the first line
-        self.set_cursor(0, line)
+        self.set_cursor(col, line)
         # Iterate through each character.
         for char in text:
             # Advance to next line if character is a new line.
             if char == '\n':
                 line += 1
-                # Move to left or right side depending on text direction.
-                col = 0 if self.displaymode & LCD_ENTRYLEFT > 0 else self._cols-1
                 self.set_cursor(col, line)
             # Write the character to the display.
             else:


### PR DESCRIPTION
Without doing that, a message would begin to be printed from where the cursor currently stands. On the first use of this method or after using `clear()`, this does not result in a problem. When a message was however already printed out before, the supposedly first line is printed at the end of the old message. When reaching the first newline character, the method jumps to the first character of the second line and continues writing there. In extreme cases (when both lines where completely filled before), this was the only visible change.
With this addition, the example script from #16 now works as expected.
