### PR TITLE
added support for backpack

### DIFF
--- a/Adafruit_CharLCD/Adafruit_CharLCD.py
+++ b/Adafruit_CharLCD/Adafruit_CharLCD.py
@@ -86,6 +86,15 @@ DOWN                    = 2
 UP                      = 3
 LEFT                    = 4
 
+# Char LCD backpack GPIO numbers.
+LCD_BACKPACK_RS         = 1
+LCD_BACKPACK_EN         = 2
+LCD_BACKPACK_D4         = 3
+LCD_BACKPACK_D5         = 4
+LCD_BACKPACK_D6         = 5
+LCD_BACKPACK_D7         = 6
+LCD_BACKPACK_LITE       = 7
+
 class Adafruit_CharLCD(object):
     """Class to represent and interact with an HD44780 character LCD display."""
 
@@ -448,3 +457,21 @@ class Adafruit_CharLCDPlate(Adafruit_RGBCharLCD):
         if button not in set((SELECT, RIGHT, DOWN, UP, LEFT)):
             raise ValueError('Unknown button, must be SELECT, RIGHT, DOWN, UP, or LEFT.')
         return self._mcp.input(button) == GPIO.LOW
+    
+
+class Adafruit_CharLCDBackpack(Adafruit_CharLCD):
+    """Class to represent and interact with an Adafruit I2C / SPI
+    LCD backpack using I2C."""
+    
+    def __init__(self, address=0x20, busnum=I2C.get_default_bus(), cols=16, lines=2):
+        """Initialize the character LCD plate.  Can optionally specify a separate
+        I2C address or bus number, but the defaults should suffice for most needs.
+        Can also optionally specify the number of columns and lines on the LCD
+        (default is 16x2).
+        """
+        # Configure the MCP23008 device.
+        self._mcp = MCP.MCP23008(address=address, busnum=busnum)
+        # Initialize LCD (with no PWM support).
+        super(Adafruit_CharLCDBackpack, self).__init__(LCD_BACKPACK_RS, LCD_BACKPACK_EN,
+            LCD_BACKPACK_D4, LCD_BACKPACK_D5, LCD_BACKPACK_D6, LCD_BACKPACK_D7,
+            cols, lines, LCD_BACKPACK_LITE, enable_pwm=False, gpio=self._mcp)

--- a/examples/char_lcd_backpack.py
+++ b/examples/char_lcd_backpack.py
@@ -1,0 +1,63 @@
+#!/usr/bin/python
+# Example using a character LCD backpack.
+import time
+
+import Adafruit_CharLCD as LCD
+
+# Define LCD column and row size for 16x2 LCD.
+lcd_columns = 16
+lcd_rows    = 2
+
+# Initialize the LCD using the pins
+lcd = LCD.Adafruit_CharLCDBackpack()
+
+# Turn backlight on
+lcd.set_backlight(0)
+
+# Print a two line message
+lcd.message('Hello\nworld!')
+
+# Wait 5 seconds
+time.sleep(5.0)
+
+# Demo showing the cursor.
+lcd.clear()
+lcd.show_cursor(True)
+lcd.message('Show cursor')
+
+time.sleep(5.0)
+
+# Demo showing the blinking cursor.
+lcd.clear()
+lcd.blink(True)
+lcd.message('Blink cursor')
+
+time.sleep(5.0)
+
+# Stop blinking and showing cursor.
+lcd.show_cursor(False)
+lcd.blink(False)
+
+# Demo scrolling message right/left.
+lcd.clear()
+message = 'Scroll'
+lcd.message(message)
+for i in range(lcd_columns-len(message)):
+    time.sleep(0.5)
+    lcd.move_right()
+for i in range(lcd_columns-len(message)):
+    time.sleep(0.5)
+    lcd.move_left()
+
+# Demo turning backlight off and on.
+lcd.clear()
+lcd.message('Flash backlight\nin 5 seconds...')
+time.sleep(5.0)
+# Turn backlight off.
+lcd.set_backlight(1)
+time.sleep(2.0)
+# Change message.
+lcd.clear()
+lcd.message('Goodbye!')
+# Turn backlight on.
+lcd.set_backlight(0)


### PR DESCRIPTION
Added support for I2C/SPI character LCD backpack (PID 292).

Only supports I2C mode.

Tested with Python 2.7 on Pi running stretch. Used RGB LCD (PID 399) soldered directly to backpack. RGB backlight control not possible. This just happened to be what I had.

New example file also added.
